### PR TITLE
feat: Implement persistent login using SharedPreferences

### DIFF
--- a/app/src/main/java/com/BusMap/busmapsv/Activity_SignUp.kt
+++ b/app/src/main/java/com/BusMap/busmapsv/Activity_SignUp.kt
@@ -6,6 +6,7 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -102,6 +103,7 @@ class Activity_SignUp : AppCompatActivity() {
     private fun goToActivityHome() {
         val intent = Intent(this, Activity_home::class.java)
         startActivity(intent)
+        finish()
     }
 
     private fun addUsers() {
@@ -127,7 +129,7 @@ class Activity_SignUp : AppCompatActivity() {
                             val userData = hashMapOf(
                                 "name" to name,
                                 "email" to email,
-                                "password" to password // Puedes considerar no almacenar la contraseña en texto plano
+                                "password" to password // Considera no almacenar la contraseña en texto plano
                             )
 
                             // Guardar la información del usuario en la colección "users"
@@ -135,8 +137,14 @@ class Activity_SignUp : AppCompatActivity() {
                                 .document(userId)
                                 .set(userData)
                                 .addOnSuccessListener {
-                                    Toast.makeText(this, "Usuario registrado correctamente, verifica tu correo electrónico", Toast.LENGTH_LONG).show()
-                                    goToActivityHome()
+                                    // Guardar el estado de inicio de sesión en SharedPreferences
+                                    val sharedPreferences = getSharedPreferences("user_prefs", MODE_PRIVATE)
+                                    val editor = sharedPreferences.edit()
+                                    editor.putBoolean("is_logged_in", true)
+                                    editor.apply()
+
+                                    showVerificationDialog()
+                                    //goToActivityHome() // Llamada para ir a la pantalla principal
                                 }
                                 .addOnFailureListener {
                                     Toast.makeText(this, "Error al guardar la información del usuario", Toast.LENGTH_LONG).show()
@@ -149,6 +157,24 @@ class Activity_SignUp : AppCompatActivity() {
                     Toast.makeText(this, "Error al registrar el usuario", Toast.LENGTH_LONG).show()
                 }
             }
+    }
+
+    private fun showVerificationDialog() {
+        val builder = AlertDialog.Builder(this)
+        builder.setTitle("Verificación de Correo")
+        builder.setMessage("Usuario registrado correctamente. Por favor, verifica tu correo electrónico para continuar.")
+
+        // Botón "Aceptar" que cierra el diálogo
+        builder.setPositiveButton("Aceptar") { dialog, _ ->
+            dialog.dismiss()  // Cierra el diálogo
+
+            // Llamada a la función que redirige a la actividad principal
+            goToActivityHome()
+        }
+
+        // Crear y mostrar el diálogo
+        val dialog: AlertDialog = builder.create()
+        dialog.show()
     }
 
 }

--- a/app/src/main/java/com/BusMap/busmapsv/MainActivity.kt
+++ b/app/src/main/java/com/BusMap/busmapsv/MainActivity.kt
@@ -18,6 +18,17 @@ class MainActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+
+        // Verificar el estado de inicio de sesión en SharedPreferences
+        val sharedPreferences = getSharedPreferences("user_prefs", MODE_PRIVATE)
+        val isLoggedIn = sharedPreferences.getBoolean("is_logged_in", false)
+
+        if (isLoggedIn) {
+            // El usuario ya ha iniciado sesión anteriormente, ir directamente a la pantalla principal
+            goToActivityHome()
+        } else {
+            // Mostrar la pantalla de inicio de sesión o registro
+        }
         val btnIngresar = findViewById<Button>(R.id.btnIngresar)
         btnIngresar.setOnClickListener {
             goToActivityLogin()
@@ -35,6 +46,10 @@ class MainActivity : AppCompatActivity() {
 
     fun goToActivityLogin() {
         val intent = Intent(this, Activity_login::class.java)
+        startActivity(intent)
+    }
+    private fun goToActivityHome() {
+        val intent = Intent(this, Activity_home::class.java)
         startActivity(intent)
     }
 }


### PR DESCRIPTION
- Added functionality to allow users to log in or register only once.
- Utilized SharedPreferences to store login state (`is_logged_in`).
- If the user is already logged in, they are redirected to the home screen without needing to log in again.
- Updated the `addUsers` function to save the login state after successful registration.
- Added logic in `onCreate` to check login status and navigate accordingly.
